### PR TITLE
Implementation of continuous marquee

### DIFF
--- a/MarqueeLabel.h
+++ b/MarqueeLabel.h
@@ -29,6 +29,7 @@
 
 #import <UIKit/UIKit.h>
 
+typedef enum MarqueeType {MLLeftRight=0, MLContinuous} MarqueeType;
 
 @interface MarqueeLabel : UIView {
     
@@ -60,6 +61,18 @@
  */
 @property (nonatomic) BOOL labelize;
 
+/* marqueeType:
+ * When set to LeftRight, the label moves from left to right and from right to left alternatively,
+ * When set to Continuous, the label slides continuously to the left.
+ * Defaults to LeftRight.
+ */
+@property (nonatomic) MarqueeType marqueeType;
+
+/* continuousMarqueeSeparator:
+ * NString inserted after label's end when marqueeType is Continuous.
+ * Defaults to @"    ".
+ */
+@property (nonatomic, strong) NSString *continuousMarqueeSeparator;
 
 /* fadeLength:
  * Sets the length of fade (from alpha 1.0 to alpha 0.0) at the edges of the

--- a/MarqueeLabelDemo/Classes/MarqueeLabelDemoViewController.m
+++ b/MarqueeLabelDemo/Classes/MarqueeLabelDemoViewController.m
@@ -105,6 +105,38 @@
     [self.view addSubview:rateLabelTwo];
     [rateLabelTwo release];
     
+    // Continuous label example
+    MarqueeLabel *continuousLabel = [[MarqueeLabel alloc] initWithFrame:CGRectMake(10, 300, self.view.frame.size.width-20, 20) rate:50.0f andFadeLength:10.0f];
+    continuousLabel.marqueeType = MLContinuous;
+    continuousLabel.numberOfLines = 1;
+    continuousLabel.opaque = NO;
+    continuousLabel.enabled = YES;
+    continuousLabel.shadowOffset = CGSizeMake(0.0, -1.0);
+    continuousLabel.textAlignment = UITextAlignmentLeft;
+    continuousLabel.textColor = [UIColor colorWithRed:0.234 green:0.234 blue:0.234 alpha:1.000];
+    continuousLabel.backgroundColor = [UIColor clearColor];
+    continuousLabel.font = [UIFont fontWithName:@"Helvetica-Bold" size:17.000];
+    continuousLabel.text = @"This is another long label that scrolls continuously rather than scrolling back and forth!";
+    
+    [self.view addSubview:continuousLabel];
+    [continuousLabel release];
+    
+    MarqueeLabel *continuousLabel2 = [[MarqueeLabel alloc] initWithFrame:CGRectMake(10, 330, self.view.frame.size.width-20, 20) rate:50.0f andFadeLength:10.0f];
+    continuousLabel2.marqueeType = MLContinuous;
+    continuousLabel2.continuousMarqueeSeparator = @"  |SEPARATOR|  ";
+    continuousLabel2.numberOfLines = 1;
+    continuousLabel2.opaque = NO;
+    continuousLabel2.enabled = YES;
+    continuousLabel2.shadowOffset = CGSizeMake(0.0, -1.0);
+    continuousLabel2.textAlignment = UITextAlignmentLeft;
+    continuousLabel2.textColor = [UIColor colorWithRed:0.234 green:0.234 blue:0.234 alpha:1.000];
+    continuousLabel2.backgroundColor = [UIColor clearColor];
+    continuousLabel2.font = [UIFont fontWithName:@"Helvetica-Bold" size:17.000];
+    continuousLabel2.text = @"This is another long label that scrolls continuously with a custom label separator!";
+    
+    [self.view addSubview:continuousLabel2];
+    [continuousLabel2 release];
+  
 }
 
 - (void)changeTheLabel {


### PR DESCRIPTION
Added two new properties : marqueeType and continuousMarqueeSeparator.
The first one is chosen in an enum(LeftRight, Continuous). When set to
Continuous, the label will loop indefinitely separated by itself by the
continuousMarqueeSeparator NSString. LeftRight is the default behavior.
Can be refactored to avoid block duplication in the setText method.
Updated the Demo accordingly.
