### PR TITLE
Small code improvements

### DIFF
--- a/CPMarqueeLabel.h
+++ b/CPMarqueeLabel.h
@@ -24,24 +24,24 @@
  */
 
 //
-//  MarqueeLabel.h
+//  CPMarqueeLabel.h
 //  
 
 #import <UIKit/UIKit.h>
 
 
-// MarqueeLabel types
+// CPMarqueeLabel types
 typedef enum {
-    MLLeftRight = 0,    // Scrolls left first, then back right to the original position
-    MLRightLeft,        // Scrolls right first, then back left to the original position
-    MLContinuous        // Continuously scrolls left (with a pause at the original position if animationDelay is set)
-} MarqueeType;
+    CPMarqueeFromLeftToRight = 0,   // Scrolls left first, then back right to the original position
+    CPMarqueeFromRightToLeft,       // Scrolls right first, then back left to the original position
+    CPMarqueeContinuous             // Continuously scrolls left (with a pause at the original position if animationDelay is set)
+} CPMarqueeType;
 
-@interface MarqueeLabel : UIView {
+@interface CPMarqueeLabel : UIView {
     
 }
 
-// MarqueeLabel-specific properties
+// CPMarqueeLabel-specific properties
 
 /* animationCurve:
  * The animation curve used in the motion of the labels. Allowable options:
@@ -58,34 +58,34 @@ typedef enum {
  * in that "home" is offset by those in order for the edge of the labels not to be
  * faded when at the home location.
  */
-@property (nonatomic, assign, readonly) BOOL awayFromHome;
+@property (nonatomic, assign, readonly, getter=isAwayFromHome) BOOL awayFromHome;
 
 
 /* labelize:
- * When set to YES, the MarqueeLabel will not move and behave like a normal UILabel
+ * When set to YES, the CPMarqueeLabel will not move and behave like a normal UILabel
  * Defaults to NO.
  */
 @property (nonatomic, assign) BOOL labelize;
 
 
 /* marqueeType:
- * When set to LeftRight, the label moves from left to right and back from right to left alternatively.
+ * When set to CPMarqueeFromLeftToRight, the label moves from left to right and back from right to left alternatively.
  *
- *      NOTE: LeftRight type is ONLY compatible with a label text alignment of UITextAlignmentLeft. Specifying
- *      LeftRight will change any previously set, non-compatible text alignment to UITextAlignmentLeft.
+ *      NOTE: CPMarqueeFromLeftToRight type is ONLY compatible with a label text alignment of UITextAlignmentLeft. Specifying
+ *      CPMarqueeFromLeftToRight will change any previously set, non-compatible text alignment to UITextAlignmentLeft.
  *
- * When set to RightLeft, the label moves from right to left and back from left to right alternatively.
+ * When set to CPMarqueeFromRightToLeft, the label moves from right to left and back from left to right alternatively.
  *
- *      NOTE: RightLeft type is ONLY compatibile with a label text alignment of UITextAlignmentRight. Specifying
- *      RightLeft will change any previously set, non-compatible text alignment to UITextAlignmentRight.
+ *      NOTE: CPMarqueeFromRightToLeft type is ONLY compatibile with a label text alignment of UITextAlignmentRight. Specifying
+ *      CPMarqueeFromRightToLeft will change any previously set, non-compatible text alignment to UITextAlignmentRight.
  *
- * When set to Continuous, the label slides continuously to the left.
+ * When set to CPMarqueeContinuous, the label slides continuously to the left.
  *
- *      NOTE: MLContinuous does support any text alignment, but will always scroll left.
+ *      NOTE: CPMarqueeContinuous does support any text alignment, but will always scroll left.
  *
- * Defaults to LeftRight.
+ * Defaults to CPMarqueeFromLeftToRight.
  */
-@property (nonatomic, assign) MarqueeType marqueeType;
+@property (nonatomic, assign) CPMarqueeType marqueeType;
 
 
 /* continuousMarqueeSeparator:
@@ -97,7 +97,7 @@ typedef enum {
 
 /* fadeLength:
  * Sets the length of fade (from alpha 1.0 to alpha 0.0) at the edges of the
- * MarqueeLabel. Cannot be larger than 1/2 of the frame width (will be santized).
+ * CPMarqueeLabel. Cannot be larger than 1/2 of the frame width (will be santized).
  */
 @property (nonatomic, assign) CGFloat fadeLength;
 
@@ -160,7 +160,7 @@ typedef enum {
 @end
 
 // Declare UILabel methods as extensions to be passed through with forwardInvocation
-@interface UILabel (MarqueeLabel)
+@interface UILabel (CPMarqueeLabel)
 
 - (CGRect)textRectForBounds:(CGRect)bounds limitedToNumberOfLines:(NSInteger)numberOfLines;
 - (void)drawTextInRect:(CGRect)rect;

--- a/CPMarqueeLabel.m
+++ b/CPMarqueeLabel.m
@@ -24,10 +24,10 @@
  */
 
 //
-//  MarqueeLabel.m
+//  CPMarqueeLabel.m
 //  
 
-#import "MarqueeLabel.h"
+#import "CPMarqueeLabel.h"
 #import <QuartzCore/QuartzCore.h>
 
 
@@ -58,9 +58,9 @@
 @end
 
 
-@interface MarqueeLabel()
+@interface CPMarqueeLabel()
 
-@property (nonatomic, assign, readwrite) BOOL awayFromHome;
+@property (nonatomic, assign, readwrite, getter=isAwayFromHome) BOOL awayFromHome;
 
 @property (nonatomic, retain) UILabel *subLabel;
 @property (nonatomic, copy) NSString *labelText;
@@ -87,7 +87,7 @@
 @end
 
 
-@implementation MarqueeLabel
+@implementation CPMarqueeLabel
 
 @synthesize subLabel = _subLabel;
 @synthesize labelText;
@@ -180,7 +180,7 @@
     if (self.fadeLength != 0.0) {
         CAGradientLayer* gradientMask = [CAGradientLayer layer];
         gradientMask.bounds = self.layer.bounds;
-        gradientMask.position = CGPointMake([self bounds].size.width / 2, [self bounds].size.height / 2);
+        gradientMask.position = CGPointMake(self.bounds.size.width / 2, self.bounds.size.height / 2);
         NSObject *transparent = (NSObject*) [[UIColor clearColor] CGColor];
         NSObject *opaque = (NSObject*) [[UIColor blackColor] CGColor];
         gradientMask.startPoint = CGPointMake(0.0, CGRectGetMidY(self.frame));
@@ -208,7 +208,7 @@
 
 - (NSTimeInterval)durationForInterval:(NSTimeInterval)interval {
     switch (self.marqueeType) {
-        case MLContinuous:
+        case CPMarqueeContinuous:
             return (interval * 2.0);
             break;
             
@@ -220,7 +220,7 @@
 
 - (void)beginScroll {
     switch (self.marqueeType) {
-        case MLContinuous:
+        case CPMarqueeContinuous:
             [self scrollLeftPerpetualWithInterval:[self durationForInterval:self.animationDuration] after:self.animationDelay];
             break;
             
@@ -361,7 +361,7 @@
             // Label is not set to be static
             
             switch (self.marqueeType) {
-                case MLContinuous:
+                case CPMarqueeContinuous:
                                         
                     // Fade out quickly
                     [UIView animateWithDuration:0.1
@@ -428,7 +428,7 @@
                     
                     break;
                     
-                case MLRightLeft:
+                case CPMarqueeFromRightToLeft:
                     
                     self.homeLabelFrame = CGRectMake(self.bounds.size.width - (expectedLabelSize.width + self.fadeLength), 0.0, expectedLabelSize.width, self.bounds.size.height);
                     self.awayLabelFrame = CGRectMake(self.fadeLength, 0.0, expectedLabelSize.width, self.bounds.size.height);
@@ -468,7 +468,7 @@
                     
                     break;
                     
-                default: //Fallback to LeftRight marqueeType
+                default: //Fallback to CPMarqueeFromLeftToRight marqueeType
                     
                     self.homeLabelFrame = CGRectMake(self.fadeLength, 0, expectedLabelSize.width, self.bounds.size.height);
                     self.awayLabelFrame = CGRectOffset(self.homeLabelFrame, -expectedLabelSize.width + (self.bounds.size.width - self.fadeLength * 2), 0.0);
@@ -639,7 +639,7 @@
         [anInvocation invokeWithTarget:self.subLabel];
     } else {
         #if TARGET_IPHONE_SIMULATOR
-            NSLog(@"Method selector not recognized by MarqueeLabel or its contained UILabel");
+            NSLog(@"Method selector not recognized by CPMarqueeLabel or its contained UILabel.");
         #endif
         [super forwardInvocation:anInvocation];
     }

--- a/MarqueeLabelDemo/Classes/MarqueeLabelDemoViewController.h
+++ b/MarqueeLabelDemo/Classes/MarqueeLabelDemoViewController.h
@@ -29,11 +29,11 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "MarqueeLabel.h"
+#import "CPMarqueeLabel.h"
 
 @interface MarqueeLabelDemoViewController : UIViewController
 
-@property (nonatomic, retain) MarqueeLabel *demoLabel;
+@property (nonatomic, retain) CPMarqueeLabel *demoLabel;
 @property (nonatomic, retain) IBOutlet UISwitch *labelizeSwitch;
 
 - (void)changeTheLabel;

--- a/MarqueeLabelDemo/Classes/MarqueeLabelDemoViewController.m
+++ b/MarqueeLabelDemo/Classes/MarqueeLabelDemoViewController.m
@@ -38,7 +38,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    MarqueeLabel *newLabel = [[MarqueeLabel alloc] initWithFrame:CGRectMake(10, 100, self.view.frame.size.width-20, 20) duration:8.0 andFadeLength:10.0f];
+    CPMarqueeLabel *newLabel = [[CPMarqueeLabel alloc] initWithFrame:CGRectMake(10, 100, self.view.frame.size.width-20, 20) duration:8.0 andFadeLength:10.0f];
     self.demoLabel = newLabel;
     [newLabel release];
     
@@ -58,7 +58,7 @@
     [NSTimer scheduledTimerWithTimeInterval:10 target:self selector:@selector(changeTheLabel) userInfo:nil repeats:NO];
     
     // Rate-speed label example
-    MarqueeLabel *rateLabelOne = [[MarqueeLabel alloc] initWithFrame:CGRectMake(10, 200, self.view.frame.size.width-20, 20) rate:50.0f andFadeLength:10.0f];
+    CPMarqueeLabel *rateLabelOne = [[CPMarqueeLabel alloc] initWithFrame:CGRectMake(10, 200, self.view.frame.size.width-20, 20) rate:50.0f andFadeLength:10.0f];
     rateLabelOne.numberOfLines = 1;
     rateLabelOne.opaque = NO;
     rateLabelOne.enabled = YES;
@@ -72,8 +72,8 @@
     [self.view addSubview:rateLabelOne];
     [rateLabelOne release];
     
-    MarqueeLabel *rateLabelTwo = [[MarqueeLabel alloc] initWithFrame:CGRectMake(10, 230, self.view.frame.size.width-20, 20) rate:50.0f andFadeLength:10.0f];
-    rateLabelTwo.marqueeType = MLRightLeft;
+    CPMarqueeLabel *rateLabelTwo = [[CPMarqueeLabel alloc] initWithFrame:CGRectMake(10, 230, self.view.frame.size.width-20, 20) rate:50.0f andFadeLength:10.0f];
+    rateLabelTwo.marqueeType = CPMarqueeFromRightToLeft;
     rateLabelTwo.numberOfLines = 1;
     rateLabelTwo.opaque = NO;
     rateLabelTwo.enabled = YES;
@@ -88,8 +88,8 @@
     [rateLabelTwo release];
     
     // Continuous label example
-    MarqueeLabel *continuousLabel = [[MarqueeLabel alloc] initWithFrame:CGRectMake(10, 300, self.view.frame.size.width-20, 20) rate:50.0f andFadeLength:10.0f];
-    continuousLabel.marqueeType = MLContinuous;
+    CPMarqueeLabel *continuousLabel = [[CPMarqueeLabel alloc] initWithFrame:CGRectMake(10, 300, self.view.frame.size.width-20, 20) rate:50.0f andFadeLength:10.0f];
+    continuousLabel.marqueeType = CPMarqueeContinuous;
     continuousLabel.numberOfLines = 1;
     continuousLabel.opaque = NO;
     continuousLabel.enabled = YES;
@@ -103,8 +103,8 @@
     [self.view addSubview:continuousLabel];
     [continuousLabel release];
     
-    MarqueeLabel *continuousLabel2 = [[MarqueeLabel alloc] initWithFrame:CGRectMake(10, 330, self.view.frame.size.width-20, 20) rate:50.0f andFadeLength:10.0f];
-    continuousLabel2.marqueeType = MLContinuous;
+    CPMarqueeLabel *continuousLabel2 = [[CPMarqueeLabel alloc] initWithFrame:CGRectMake(10, 330, self.view.frame.size.width-20, 20) rate:50.0f andFadeLength:10.0f];
+    continuousLabel2.marqueeType = CPMarqueeContinuous;
     continuousLabel2.continuousMarqueeSeparator = @"  |SEPARATOR|  ";
     continuousLabel2.animationCurve = UIViewAnimationOptionCurveLinear;
     continuousLabel2.numberOfLines = 1;
@@ -128,8 +128,8 @@
 
 - (IBAction)labelizeSwitched:(UISwitch *)sender {
     for (UIView *v in self.view.subviews) {
-        if ([v isKindOfClass:[MarqueeLabel class]]) {
-            [(MarqueeLabel *)v setLabelize:sender.on];
+        if ([v isKindOfClass:[CPMarqueeLabel class]]) {
+            [(CPMarqueeLabel *)v setLabelize:sender.on];
         }
     }
 }

--- a/MarqueeLabelDemo/MarqueeLabelDemo.xcodeproj/project.pbxproj
+++ b/MarqueeLabelDemo/MarqueeLabelDemo.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		2899E5220DE3E06400AC0155 /* MarqueeLabelDemoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2899E5210DE3E06400AC0155 /* MarqueeLabelDemoViewController.xib */; };
 		28AD733F0D9D9553002E5188 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD733E0D9D9553002E5188 /* MainWindow.xib */; };
 		28D7ACF80DDB3853001CB0EB /* MarqueeLabelDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28D7ACF70DDB3853001CB0EB /* MarqueeLabelDemoViewController.m */; };
-		EA646A1412F7A5B000F31B16 /* MarqueeLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = EA646A1312F7A5B000F31B16 /* MarqueeLabel.m */; };
+		EA646A1412F7A5B000F31B16 /* CPMarqueeLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = EA646A1312F7A5B000F31B16 /* CPMarqueeLabel.m */; };
 		EABFD31A150D55CC00216FCE /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EABFD319150D55CC00216FCE /* QuartzCore.framework */; };
 /* End PBXBuildFile section */
 
@@ -33,8 +33,8 @@
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		32CA4F630368D1EE00C91783 /* MarqueeLabelDemo_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MarqueeLabelDemo_Prefix.pch; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* MarqueeLabelDemo-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "MarqueeLabelDemo-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
-		EA646A1212F7A5B000F31B16 /* MarqueeLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MarqueeLabel.h; path = ../MarqueeLabel.h; sourceTree = SOURCE_ROOT; };
-		EA646A1312F7A5B000F31B16 /* MarqueeLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MarqueeLabel.m; path = ../MarqueeLabel.m; sourceTree = SOURCE_ROOT; };
+		EA646A1212F7A5B000F31B16 /* CPMarqueeLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; name = CPMarqueeLabel.h; path = ../CPMarqueeLabel.h; sourceTree = SOURCE_ROOT; };
+		EA646A1312F7A5B000F31B16 /* CPMarqueeLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CPMarqueeLabel.m; path = ../CPMarqueeLabel.m; sourceTree = SOURCE_ROOT; };
 		EABFD319150D55CC00216FCE /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -56,8 +56,8 @@
 		080E96DDFE201D6D7F000001 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				EA646A1212F7A5B000F31B16 /* MarqueeLabel.h */,
-				EA646A1312F7A5B000F31B16 /* MarqueeLabel.m */,
+				EA646A1212F7A5B000F31B16 /* CPMarqueeLabel.h */,
+				EA646A1312F7A5B000F31B16 /* CPMarqueeLabel.m */,
 				1D3623240D0F684500981E51 /* MarqueeLabelDemoAppDelegate.h */,
 				1D3623250D0F684500981E51 /* MarqueeLabelDemoAppDelegate.m */,
 				28D7ACF60DDB3853001CB0EB /* MarqueeLabelDemoViewController.h */,
@@ -183,7 +183,7 @@
 				1D60589B0D05DD56006BFB54 /* main.m in Sources */,
 				1D3623260D0F684500981E51 /* MarqueeLabelDemoAppDelegate.m in Sources */,
 				28D7ACF80DDB3853001CB0EB /* MarqueeLabelDemoViewController.m in Sources */,
-				EA646A1412F7A5B000F31B16 /* MarqueeLabel.m in Sources */,
+				EA646A1412F7A5B000F31B16 /* CPMarqueeLabel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
I fixed some type conversions and searched for possible bugs.
One question: Why do you do the 0.1 second long fade in/out every time the text changes? This looks rather ugly when you see it on the device and changing the text immediately is what UILabel does, too. In my opinion any interface object should not animate much more than you want it to do and a simple fade can be achieved in a controller class easily instead of inside the label's class.
