### PR TITLE
Fixed issue where non-scrolling continuous text wasn't centred properly.

### DIFF
--- a/MarqueeLabel.m
+++ b/MarqueeLabel.m
@@ -291,7 +291,7 @@ NSString *const kMarqueeLabelShouldAnimateNotification = @"MarqueeLabelShouldAni
                     
                 } else { //Will not scroll
                     if (self.subLabel.textAlignment == UITextAlignmentCenter) {
-                        CGRect labelFrame = CGRectMake(self.fadeLength, 0, self.bounds.size.width - self.fadeLength, self.bounds.size.height);
+                        CGRect labelFrame = CGRectMake(self.fadeLength, 0, self.bounds.size.width - (self.fadeLength * 2), self.bounds.size.height);
                         self.homeLabelFrame = labelFrame;
                         self.awayLabelFrame = labelFrame;
                     }


### PR DESCRIPTION
The fadeLength wasn't being properly taken into account when
calculating the label frame, causing the text to be slightly off-centre.
