### PR TITLE
Fix for EXC_BAD_INSTRUCTION

### DIFF
--- a/MarqueeLabel.m
+++ b/MarqueeLabel.m
@@ -202,6 +202,7 @@ NSString *const kMarqueeLabelShouldAnimateNotification = @"MarqueeLabelShouldAni
     _isPaused = NO;
     self.labelText = @"";  // Set to zero-length string to start, so that self.text returns a non-nil string (allows appending, etc)
     self.animationDelay = 1.0;
+    self.animationDuration = 0.0f; // initialize animation duration
     
     // Add notification observers
     // Custom class notifications


### PR DESCRIPTION
Initialize animationDuration variable (was getting EXC_BAD_INSTRUCTION on line 338 of MarqueeLabel.m)
