### PR TITLE
Make MarqueeLabel compatible with auto-layout

### DIFF
--- a/MarqueeLabel.m
+++ b/MarqueeLabel.m
@@ -701,6 +701,19 @@ typedef void (^animationCompletionBlock)(void);
     [self updateSublabelAndLocationsAndBeginScroll:!self.orientationWillChange];
 }
 
+- (void)setBounds:(CGRect)bounds {
+    CGRect oldBounds = self.bounds;
+    
+    [super setBounds:bounds];
+    
+    if (CGSizeEqualToSize(bounds.size, oldBounds.size)) {
+        return;
+    }
+    
+    [self applyGradientMaskForFadeLength:self.fadeLength animated:!self.orientationWillChange];
+    [self updateSublabelAndLocationsAndBeginScroll:!self.orientationWillChange];
+}
+
 - (NSString *)text {
     return self.subLabel.text;
 }
@@ -801,6 +814,10 @@ typedef void (^animationCompletionBlock)(void);
 
 - (void)setBaselineAdjustment:(UIBaselineAdjustment)baselineAdjustment {
     [self updateSubLabelsForKey:@"baselineAdjustment" withValue:@(baselineAdjustment)];
+}
+
+- (CGSize)intrinsicContentSize {
+    return self.subLabel.intrinsicContentSize;
 }
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000


### PR DESCRIPTION
This fixes the MarqueeLabel for the auto-layout system. This addresses issue #39.

Here is the code I used to test with as I did not add an example to the existing demo application. 

``` objective-c
MarqueeLabel* label = [[MarqueeLabel alloc] initWithFrame:CGRectZero];
[label setTranslatesAutoresizingMaskIntoConstraints:FALSE];
[label setBackgroundColor:[UIColor grayColor]];
[label setText:@"This is a long message. It is used to test if the MarqueeLabel works correctly with auto-layout."];

[[self view] addSubview:label];

NSDictionary* views = NSDictionaryOfVariableBindings(label);

// Layout the marquee label at the top of the view with standard spacing on the left, right, and top. The marquee label is pinned to the top of it's superview.
[[self view] addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-[label]" options:0 metrics:nil views:views]];
[[self view] addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[label]-|" options:0 metrics:nil views:views]];
```
