### PR TITLE
Changed iOS6 check for performance and convenience reasons

### DIFF
--- a/MarqueeLabel.m
+++ b/MarqueeLabel.m
@@ -450,7 +450,7 @@ typedef void (^animationCompletionBlock)(void);
     CGSize maximumLabelSize = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
     
     // Check for attributed string attributes
-    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 6.0) {
+    if ([self.subLabel respondsToSelector:@selector(attributedText)]) {
         // Calculate based on attributed text
         expectedLabelSize = [self.subLabel.attributedText boundingRectWithSize:maximumLabelSize
                                                                        options:0


### PR DESCRIPTION
When using MarqueeLabel in UITableViewCell, the iOS6 check slows down scrolling
<code>if([[[UIDevice currentDevice] systemVersion] floatValue] >= 6.0)</code>
this way is also not 100% safe to check with. I recommend this way:
<code>if ([self.subLabel respondsToSelector:@selector(attributedText)])</code>

This pushes performance a little bit.

Steve
