### PR TITLE
Fixed a bug which occurred in some rare cases where one of the sublabels...

### DIFF
--- a/MarqueeLabel.m
+++ b/MarqueeLabel.m
@@ -1129,6 +1129,7 @@ CGPoint MLOffsetCGPoint(CGPoint point, CGFloat offset);
     for (UILabel *sl in subLabels) {
         sl.attributedText = self.attributedText;
         sl.backgroundColor = self.backgroundColor;
+        sl.textColor = self.textColor;
         sl.shadowColor = self.shadowColor;
         sl.shadowOffset = self.shadowOffset;
         sl.textAlignment = NSTextAlignmentLeft;


### PR DESCRIPTION
... would remain unaffected by text color change e.g. black, while scrolling inside of a collection view (possibly any such container which reuses cells).
