### PR TITLE
Fix an error is swift version for iOS 7

### DIFF
--- a/Sources/Swift/MarqueeLabel.swift
+++ b/Sources/Swift/MarqueeLabel.swift
@@ -462,6 +462,7 @@ public class MarqueeLabel: UILabel {
         forwardPropertiesToSublabel()
     }
     
+    @available(iOS 8.0, *)
     public override func prepareForInterfaceBuilder() {
         super.prepareForInterfaceBuilder()
         forwardPropertiesToSublabel()


### PR DESCRIPTION
prepareForInterfaceBuilder() is an iOS 8 method