### PR TITLE
fix memory leak

### DIFF
--- a/Sources/ObjC/MarqueeLabel.m
+++ b/Sources/ObjC/MarqueeLabel.m
@@ -655,6 +655,7 @@ CGPoint MLOffsetCGPoint(CGPoint point, CGFloat offset);
     }
     
     __weak __typeof__(self) weakSelf = self;
+    __weak __typeof__(labelAnimation) weakLabelAnimation = labelAnimation;
     self.scrollCompletionBlock = ^(BOOL finished) {
         if (!finished || !weakSelf) {
             // Do not continue into the next loop
@@ -672,7 +673,7 @@ CGPoint MLOffsetCGPoint(CGPoint point, CGFloat offset);
             if (weakSelf.labelShouldScroll && !weakSelf.tapToScroll && !weakSelf.holdScrolling) {
                 [weakSelf scrollContinuousWithInterval:interval
                                              after:delayAmount
-                                    labelAnimation:labelAnimation
+                                    labelAnimation:weakLabelAnimation
                                  gradientAnimation:gradientAnimation];
             }
         }


### PR DESCRIPTION
Hi there, you can reproduce the memory leak when using code below. The dealloc of MarqueeLabel will not be called.
```
self.demoLabel.text = @"When shall we three meet again in thunder, lightning, or in rain? When the hurlyburly's done, When the battle 's lost and won.";
self.demoLabel.textColor = [UIColor blueColor];
self.demoLabel.font = [UIFont systemFontOfSize:15];
self.demoLabel.marqueeType = MLContinuous;
self.demoLabel.scrollDuration = 10.0f;
self.demoLabel.fadeLength = 10.0f;
self.demoLabel.textAlignment = NSTextAlignmentLeft;
```
I try to fix this issue by weakify labelAnimation.  
Another option is clear self.scrollCompletionBlock when animationDidStop.