### PR TITLE
Bump version

### DIFF
--- a/MarqueeLabel/Info.plist
+++ b/MarqueeLabel/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>3.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/MarqueeLabel/MarqueeLabel/Info.plist
+++ b/MarqueeLabel/MarqueeLabel/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>3.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/MarqueeLabelSwift/Info.plist
+++ b/MarqueeLabelSwift/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>3.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/MarqueeLabelSwift/MarqueeLabelSwift/Info.plist
+++ b/MarqueeLabelSwift/MarqueeLabelSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>3.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/MarqueeLabelTV/Info.plist
+++ b/MarqueeLabelTV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>3.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/MarqueeLabelTV/MarqueeLabelTV/Info.plist
+++ b/MarqueeLabelTV/MarqueeLabelTV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>3.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Set git tag value to CFBundleShortVersionString in Info.plist as to be able to check the version of framework.

```
$ cd MarqueeLabel-repository
$ find . -name 'Info.plist' -exec echo {} \;                                                                                                         
./MarqueeLabel/Info.plist
./MarqueeLabel/MarqueeLabel/Info.plist
./MarqueeLabelSwift/Info.plist
./MarqueeLabelSwift/MarqueeLabelSwift/Info.plist
./MarqueeLabelTV/Info.plist
./MarqueeLabelTV/MarqueeLabelTV/Info.plist
$ find . -name 'Info.plist' -exec /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString 3.0.5" {} \; // 3.0.5 is latest git tag.
```