### PR TITLE
MarqueeLabel's isAccessibilityElement being set causes sublabel isAcc…

### DIFF
--- a/Sources/ObjC/MarqueeLabel.m
+++ b/Sources/ObjC/MarqueeLabel.m
@@ -1359,6 +1359,10 @@ CGPoint MLOffsetCGPoint(CGPoint point, CGFloat offset);
     self.subLabel.contentMode = contentMode;
 }
 
+- (void)setIsAccessibilityElement:(BOOL)isAccessibilityElement {
+    [super setIsAccessibilityElement:isAccessibilityElement];
+    self.subLabel.isAccessibilityElement = isAccessibilityElement;
+}
 
 #pragma mark - Custom Getters and Setters
 

--- a/Sources/Swift/MarqueeLabel.swift
+++ b/Sources/Swift/MarqueeLabel.swift
@@ -1572,6 +1572,11 @@ open class MarqueeLabel: UILabel, CAAnimationDelegate {
         }
     }
     
+    open override var isAccessibilityElement: Bool {
+        didSet {
+            sublabel.isAccessibilityElement = self.isAccessibilityElement
+        }
+    }
 
     //
     // MARK: - Support


### PR DESCRIPTION
…essibilityElement to be set to same

useful when using MarqueeLabel to display content that is not text.

thanks for your work on this!