### PR TITLE
Allows use of frameworks in app extensions

### DIFF
--- a/MarqueeLabel/MarqueeLabel.xcodeproj/project.pbxproj
+++ b/MarqueeLabel/MarqueeLabel.xcodeproj/project.pbxproj
@@ -423,6 +423,7 @@
 		EAE4AC771CA8DCBB006C1ECC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -446,6 +447,7 @@
 		EAE4AC781CA8DCBB006C1ECC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;

--- a/MarqueeLabelSwift/MarqueeLabelSwift.xcodeproj/project.pbxproj
+++ b/MarqueeLabelSwift/MarqueeLabelSwift.xcodeproj/project.pbxproj
@@ -425,6 +425,7 @@
 		EAE4AC851CA8DE70006C1ECC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -450,6 +451,7 @@
 		EAE4AC861CA8DE70006C1ECC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Sets APPLICATION_EXTENSION_API_ONLY project flags to true so that the frameworks can be linked against an extension.