### PR TITLE
Remove Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,0 @@
-import PackageDescription
-
-let package = Package(
-    name: "MarqueeLabel"
-)


### PR DESCRIPTION
From Xcode 11 beta, Carthage build has failed since this module is distinguished as Swift Package.
To solve it, as workaround, we should remove Package.swift temporally.

```
[MT] DVTAssertions: ASSERTION FAILURE in /Library/Caches/com.apple.xbs/Sources/IDEFrameworks/IDEFrameworks-14855.18/IDEFoundation/ProjectModel/Containers/IDEContainer.m:553
Details:  Error: Mismatch between existing container extension: <DVTExtension 0x7ff0ace170f0: Folder (Xcode.IDEFoundation.Container.Folder) v0.1 from com.apple.dt.IDEFoundation> and requested container extension: <DVTExtension 0x7ff08f303bf0: Swift User Managed Package Folder (Xcode.IDEFoundation.Container.SwiftPackageUserManagedFolder) v0.1 from com.apple.dt.IDE.IDESwiftPackageSupport> for file path: <DVTFilePath:0x7ff08f456e40:'/Users/***/Carthage/Checkouts/MarqueeLabel/Extras'>
Object:   <IDEContainer>
Method:   +_retainedContainerAtFilePath:fileDataType:workspace:options:error:
Thread:   <NSThread: 0x7ff0acc159c0>{number = 1, name = main}
Hints:

Backtrace:
  0   -[DVTAssertionHandler handleFailureInMethod:object:fileName:lineNumber:assertionSignature:messageFormat:arguments:] (in DVTFoundation)
  1   _DVTAssertionHandler (in DVTFoundation)
  2   _DVTAssertionFailureHandler (in DVTFoundation)
  3   __82+[IDEContainer _retainedContainerAtFilePath:fileDataType:workspace:options:error:]_block_invoke_2 (in IDEFoundation)
  4   _dispatch_client_callout (in libdispatch.dylib)
  5   _dispatch_lane_barrier_sync_invoke_and_complete (in libdispatch.dylib)
  6   DVTDispatchBarrierSync (in DVTFoundation)
  7   -[DVTDispatchLock performLockedBlock:] (in DVTFoundation)
  8   __82+[IDEContainer _retainedContainerAtFilePath:fileDataType:workspace:options:error:]_block_invoke (in IDEFoundation)
  9   __58-[DVTModelObjectGraph performBlockCoalescingModelChanges:]_block_invoke (in DVTFoundation)
 10   -[DVTModelGraphTransactionScope performTransaction:] (in DVTFoundation)
 11   -[DVTModelObjectGraph performBlockCoalescingModelChanges:] (in DVTFoundation)
 12   +[IDEContainer _retainedContainerAtFilePath:fileDataType:workspace:options:error:] (in IDEFoundation)
 13   +[IDEContainer retainedContainerAtFilePath:fileDataType:workspace:error:] (in IDEFoundation)
 14   -[IDEFileReference _recalculateReferencedContainer] (in IDEFoundation)
 15   -[IDEFileReference referencedContainer] (in IDEFoundation)
 16   -[IDEContainer _resolveFileReference:] (in IDEFoundation)
 17   __67-[IDEContainer initWithFilePath:extension:workspace:options:error:]_block_invoke.414 (in IDEFoundation)
 18   -[_DVTTimeSlicedMainThreadUnorderedUniquingWorkQueue _processWorkItemsWithDeadline:] (in DVTFoundation)
 19   -[DVTTimeSlicedMainThreadWorkQueue _processWithDeadline:] (in DVTFoundation)
 20   -[_DVTTimeSlicedMainThreadActiveWorkQueues _processWorkQueuesOnDeadline] (in DVTFoundation)
 21   __NSFireDelayedPerform (in Foundation)
 22   __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ (in CoreFoundation)
 23   __CFRunLoopDoTimer (in CoreFoundation)
 24   __CFRunLoopDoTimers (in CoreFoundation)
 25   __CFRunLoopRun (in CoreFoundation)
 26   CFRunLoopRunSpecific (in CoreFoundation)
 27   +[DVTKVOConditionValidator waitForCondition:sourceObject:keyPathAffectingConditionBlock:timeout:] (in DVTFoundation)
 28   -[Xcode3CommandLineBuildTool _resolveInputOptionsWithTimingSection:] (in Xcode3Core)
 29   -[Xcode3CommandLineBuildTool run] (in Xcode3Core)
 30   main (in xcodebuild)
 31   start (in libdyld.dylib)
```