### PR TITLE
Fix swift-tools-version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Without this change, it would not be possible to build MarqueeLabel with Xcode 10.3.

One may argue that SPM is only integrated starting with Xcode 11 (which includes Swift 5.1), but there are other dependency managers relying on the Package.swift manifest like [Accio](https://github.com/JamitLabs/Accio) and sometimes they are still used with Xcode 10.3.

Also after having merged this, it would good to release a new version.