### PR TITLE
Fixed the parameter of labelReturnedToHome method

### DIFF
--- a/Sources/MarqueeLabel.swift
+++ b/Sources/MarqueeLabel.swift
@@ -854,7 +854,7 @@ open class MarqueeLabel: UILabel, CAAnimationDelegate {
             }
             
             // Call returned home function
-            self!.labelReturnedToHome(true)
+            self!.labelReturnedToHome(finished)
             
             // Check to ensure that:
             


### PR DESCRIPTION
Check that the parameter of `labelReturnedToHome `called when `scrollCompletionBlock` is executed is `true` Changed to `finished` value of animation result.

This is because when `labelReturnedToHome` was extended by `override`, it was necessary to determine whether the callback occurred during the animation or that the animation ended normally.

I added a process to get a new character string when scrolling was completely completed, but when `text` was set (animation stopped midway), `labelReturnedToHome` was called, so I could not control what I wanted to do did.