### PR TITLE
Support for automatic font size shrinking

### DIFF
--- a/Sources/MarqueeLabel.swift
+++ b/Sources/MarqueeLabel.swift
@@ -768,7 +768,7 @@ open class MarqueeLabel: UILabel, CAAnimationDelegate {
             let expectedMinimumTextSize = resizedString.size()
             
             // If even after shrinking it's too wide, consider the label too large and in need of scrolling
-            labelTooLarge = self.bounds.size.width < expectedMinimumTextSize.width + CGFloat.ulpOfOne
+            labelTooLarge = self.bounds.size.width < ceil(expectedMinimumTextSize.width) + CGFloat.ulpOfOne
             
             // Set scale factor on sublabel dependent on result, back to 1.0 if too big to prevent
             // sublabel from shrinking AND scrolling

--- a/Sources/MarqueeLabel.swift
+++ b/Sources/MarqueeLabel.swift
@@ -583,7 +583,7 @@ open class MarqueeLabel: UILabel, CAAnimationDelegate {
         }
         
         // Calculate expected size
-        let expectedLabelSize = sublabelSize()
+        let expectedLabelSize = sublabel.desiredSize()
         
         // Invalidate intrinsic size
         invalidateIntrinsicContentSize()
@@ -721,25 +721,6 @@ open class MarqueeLabel: UILabel, CAAnimationDelegate {
         }
     }
     
-    private func sublabelSize() -> CGSize {
-        // Bound the expected size
-        let maximumLabelSize = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
-        // Calculate the expected size
-        var expectedLabelSize = sublabel.sizeThatFits(maximumLabelSize)
-        
-        #if os(tvOS)
-            // Sanitize width to 16384.0 (largest width a UILabel will draw on tvOS)
-            expectedLabelSize.width = min(expectedLabelSize.width, 16384.0)
-        #else
-            // Sanitize width to 5461.0 (largest width a UILabel will draw on an iPhone 6S Plus)
-            expectedLabelSize.width = min(expectedLabelSize.width, 5461.0)
-        #endif
-
-        // Adjust to own height (make text baseline match normal label)
-        expectedLabelSize.height = bounds.size.height
-        return expectedLabelSize
-    }
-    
     override open func sizeThatFits(_ size: CGSize) -> CGSize {
         var fitSize = sublabel.sizeThatFits(size)
         fitSize.width += leadingBuffer
@@ -752,12 +733,12 @@ open class MarqueeLabel: UILabel, CAAnimationDelegate {
     
     open func labelShouldScroll() -> Bool {
         // Check for nil string
-        if sublabel.text == nil {
+        guard sublabel.text != nil else {
             return false
         }
         
         // Check for empty string
-        if sublabel.text!.isEmpty {
+        guard !sublabel.text!.isEmpty else {
             return false
         }
         
@@ -1736,6 +1717,27 @@ fileprivate typealias MLAnimationCompletionBlock = (_ finished: Bool) -> Void
 fileprivate typealias MLAnimation = (anim: CAKeyframeAnimation, duration: CGFloat)
 
 fileprivate class GradientSetupAnimation: CABasicAnimation {
+}
+
+fileprivate extension UILabel {
+    func desiredSize() -> CGSize {
+        // Bound the expected size
+        let maximumLabelSize = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        // Calculate the expected size
+        var expectedLabelSize = self.sizeThatFits(maximumLabelSize)
+        
+        #if os(tvOS)
+            // Sanitize width to 16384.0 (largest width a UILabel will draw on tvOS)
+            expectedLabelSize.width = min(expectedLabelSize.width, 16384.0)
+        #else
+            // Sanitize width to 5461.0 (largest width a UILabel will draw on an iPhone 6S Plus)
+            expectedLabelSize.width = min(expectedLabelSize.width, 5461.0)
+        #endif
+
+        // Adjust to own height (make text baseline match normal label)
+        expectedLabelSize.height = bounds.size.height
+        return expectedLabelSize
+    }
 }
 
 fileprivate extension UIResponder {


### PR DESCRIPTION
In my app's use-case, the scrolling label is used as a window title and is the only scrolling label in the whole view. 
However more often than not the text will be just a tiny bit too long (like, half a character too long) and make the label start scrolling.

To solve this, I've decided to allow the label to shrink the font until about 85% of it's original size where it becomes less easy to read, and only if it still won't fit, let iit scroll.

Thus with this change the component should now support the Minimum Font Scale / Minimum Font Size properties in Interface Builder to allow the label to shrink before it starts scrolling.