### PR TITLE
remove invaild excludes in SPM file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "MarqueeLabel",
-	          path: "Sources",
-            exclude: ["Carthage", "Extras", "MarqueeLabel", "MarqueeLabelTV", "Metadata", "CHANGELOG.md", "MarqueeLabel.podpsec"])
+            path: "Sources")
     ],
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
remove the excludes that causes warnings in xcode 13 (excludes referenced not existing paths)