### PR TITLE
added workaround for Xcode 14b1

### DIFF
--- a/Sources/MarqueeLabel.swift
+++ b/Sources/MarqueeLabel.swift
@@ -657,7 +657,10 @@ open class MarqueeLabel: UILabel, CAAnimationDelegate {
             let labelFrame: CGRect
             switch type {
             case .continuousReverse, .rightLeft:
-                labelFrame = bounds.divided(atDistance: leadingBuffer, from: CGRectEdge.maxXEdge).remainder.integral
+                // symbol of this CoreGraphics func is not found in libswiftCoreGraphics.dylib when compiled with Xcode 14b1
+//                labelFrame = bounds.divided(atDistance: leadingBuffer, from: CGRectEdge.maxXEdge).remainder.integral
+                let integralWidth = max(0, min(bounds.width, bounds.width - leadingBuffer))
+                labelFrame = CGRect(origin: bounds.origin, size: .init(width: integralWidth, height: bounds.height))
             default:
                 labelFrame = CGRect(x: leadingBuffer, y: 0.0, width: bounds.size.width - leadingBuffer, height: bounds.size.height).integral
             }


### PR DESCRIPTION
When compiling with Xcode 14b1 and running on an iOS 15 device I get a symbol not found crash:

```
error: cannot add command: user command exists and force replace not set
dyld[73442]: Symbol not found: (_$sSo6CGRectV12CoreGraphicsE9__divided5slice9remainder10atDistance4fromySpyABG_AiC7CGFloatVSo0A4EdgeVtF)
  Referenced from: '/private/var/containers/Bundle/Application/BBE0289A-DCA1-4B96-A6B4-E100833D55DF/SomeApp.app/Frameworks/MarqueeLabel.framework/MarqueeLabel'
  Expected in: '/usr/lib/swift/libswiftCoreGraphics.dylib'
Symbol not found: (_$sSo6CGRectV12CoreGraphicsE9__divided5slice9remainder10atDistance4fromySpyABG_AiC7CGFloatVSo0A4EdgeVtF)
  Referenced from: '/private/var/containers/Bundle/Application/BBE0289A-DCA1-4B96-A6B4-E100833D55DF/SomeApp.app/Frameworks/MarqueeLabel.framework/MarqueeLabel'
  Expected in: '/usr/lib/swift/libswiftCoreGraphics.dylib'
```

This PR implements a workaround by no longer using the CoreGraphics utility function.