### PR TITLE
Fix triggerScrollStart() so that it can properly ignore prevention conditions

### DIFF
--- a/Sources/MarqueeLabel.swift
+++ b/Sources/MarqueeLabel.swift
@@ -1337,7 +1337,7 @@ open class MarqueeLabel: UILabel, CAAnimationDelegate {
     */
     public func triggerScrollStart() {
         if labelShouldScroll() && !awayFromHome {
-            updateAndScroll()
+            updateAndScroll(overrideHold: true)
         }
     }
     


### PR DESCRIPTION
The documentation comment for `triggerScrollStart()` describes:

> Overrides any non-size condition which is preventing the receiver from automatically scrolling, and begins a scroll animation.
> Currently the only non-size conditions which can prevent a label from scrolling are the `tapToScroll` and `holdScrolling` properties.

https://github.com/cbpowell/MarqueeLabel/blob/bfab54b316126f0fef03be49a1c54142bd728b34/Sources/MarqueeLabel.swift#L1325-L1327

However, invoking `triggerScrollStart()` on a label with `holdScrolling = true` does not trigger scroll.
This PR fixes the issue by calling `updateAndScroll()` with `overrideHold: true` option.