### PR TITLE
Bump supported platforms to avoid deprecation warning with Xcode 16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "MarqueeLabel",
     platforms: [
-        .iOS(.v11),
-        .tvOS(.v11)
+        .iOS(.v12),
+        .tvOS(.v12)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "MarqueeLabel",
     platforms: [
-        .iOS(.v11),
-        .tvOS(.v11),
+        .iOS(.v12),
+        .tvOS(.v12),
         .visionOS(.v1)
     ],
     products: [


### PR DESCRIPTION
This is basically the same as https://github.com/cbpowell/MarqueeLabel/pull/294, but for Xcode 16.