### PR TITLE
Remove Width Limit

### DIFF
--- a/Sources/MarqueeLabel.swift
+++ b/Sources/MarqueeLabel.swift
@@ -2009,14 +2009,6 @@ fileprivate extension UILabel {
         // Calculate the expected size
         var expectedLabelSize = self.sizeThatFits(maximumLabelSize)
         
-        #if os(tvOS)
-            // Sanitize width to 16384.0 (largest width a UILabel will draw on tvOS)
-            expectedLabelSize.width = min(expectedLabelSize.width, 16384.0)
-        #else
-            // Sanitize width to 5461.0 (largest width a UILabel will draw on an iPhone 6S Plus)
-            expectedLabelSize.width = min(expectedLabelSize.width, 5461.0)
-        #endif
-
         // Adjust to own height (make text baseline match normal label)
         expectedLabelSize.height = bounds.size.height
         return expectedLabelSize


### PR DESCRIPTION
## Problem
Labels with long text were being truncated with "..." due to 
hardcoded width limits applied to all platforms:
- tvOS: 16384.0
- iOS: 5461.0 (based on iPhone 6S Plus)

These limits cause incorrect truncation when the label's content 
exceeds the hardcoded maximum width.

## Solution
Removed the platform-specific width sanitization block entirely,
allowing `expectedLabelSize` to reflect the true content width
without artificial limits.

## Changes
- Removed `#if os(tvOS) / #else / #endif` width cap block 
  in `MarqueeLabel.swift`